### PR TITLE
Feature/bootstrap xosera ansiterm

### DIFF
--- a/code/firmware/rosco_m68k_pro_development/rosco_m68k_pro_firmware_2M.ld
+++ b/code/firmware/rosco_m68k_pro_development/rosco_m68k_pro_firmware_2M.ld
@@ -13,7 +13,7 @@ PROVIDE(_EFP_RECVCHAR   = 0x00000434);  /* Receive a character via UART */
 PROVIDE(_EFP_CHECKCHAR  = 0x00000444);  /* Check char ready from UART   */
 PROVIDE(XANSI_CON_DATA  = 0x00000500);  /* XANSI data ($0500-$057F)     */
 
-PROVIDE(_FIRMWARE_REV   = 0x00E00400);  /* firmware revision code       */
+PROVIDE(_FIRMWARE_REV   = 0xFF000400);  /* firmware revision code       */
 
 SECTIONS
 {

--- a/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_ansiterm_m68k.c
+++ b/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_ansiterm_m68k.c
@@ -37,10 +37,6 @@
 #else
 
 #define DEBUG 0        // must be zero (no printf in firmware)
-// thse are missing from kernel machine.h
-extern unsigned int _FIRMWARE_REV;        // rosco ROM firmware revision
-extern void (*_EFP_RECVCHAR)();
-extern void (*_EFP_CHECKCHAR)();
 
 #endif
 
@@ -1769,7 +1765,7 @@ static const char xansiterm_banner[] =
     "|  _| . |_ -| _| . |     |     | . | . | '_|\r\n"
     "|_| |___|___|__|___|_____|_|_|_|___|___|_,_|\r\n"
     "\x1b[35mX\x1b[93mo\x1b[33ms\x1b[96me\x1b[92mr\x1b[91ma \x1b[0mv";                     // 0.20
-static const char xansiterm_banner2[] = " XANSI \x1b[93m|_____|\x1b[0m   Classic ";        // 2.0.DEV\r\n;
+static const char xansiterm_banner2[] = " XANSI \x1b[93m|_____|\x1b[0m   Pro     ";        // 2.0.DEV\r\n;
 
 // initialize terminal functions
 // TODO: ICP default values

--- a/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_api.h
+++ b/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_api.h
@@ -107,7 +107,7 @@ typedef struct _xreg
     {                                                                                                                  \
         (void)(XM_##xmreg);                                                                                            \
         uint16_t uval16 = (word_value);                                                                                \
-        __asm__ __volatile__("move.w %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
+        __asm__ __volatile__("move.w %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                            \
                              :                                                                                         \
                              : [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                                \
                              :);                                                                                       \
@@ -119,12 +119,12 @@ typedef struct _xreg
     {                                                                                                                  \
         (void)(XM_##xmreg);                                                                                            \
         uint32_t uval32 = (long_value);                                                                                \
-        __asm__ __volatile__("move.l %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
+        __asm__ __volatile__("move.l %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                            \
                              :                                                                                         \
                              : [src] "d"(uval32), [ptr] "a"(xosera_ptr)                                                \
                              :);                                                                                       \
     } while (false)
-// set XR register XR_<xreg> to 16-bit word word_value (uses MOVEP.L if reg and value are constant)
+// set XR register XR_<xreg> to 16-bit word word_value (uses MOVE.L if reg and value are constant)
 #define xreg_setw(xreg, word_value)                                                                                    \
     do                                                                                                                 \
     {                                                                                                                  \
@@ -132,7 +132,7 @@ typedef struct _xreg
         uint16_t uval16 = (word_value);                                                                                \
         if (__builtin_constant_p((XR_##xreg)) && __builtin_constant_p((word_value)))                                   \
         {                                                                                                              \
-            __asm__ __volatile__("move.l %[rxav]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; "                                   \
+            __asm__ __volatile__("move.l %[rxav]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; "                                    \
                                  :                                                                                     \
                                  : [rxav] "d"(((XR_##xreg) << 16) | (uint16_t)((word_value))), [ptr] "a"(xosera_ptr)   \
                                  :);                                                                                   \
@@ -140,7 +140,7 @@ typedef struct _xreg
         else                                                                                                           \
         {                                                                                                              \
             __asm__ __volatile__(                                                                                      \
-                "move.w %[rxa]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; move.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"        \
+                "move.w %[rxa]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; move.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"          \
                 :                                                                                                      \
                 : [rxa] "d"((XR_##xreg)), [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                     \
                 :);                                                                                                    \
@@ -154,7 +154,7 @@ typedef struct _xreg
         uint16_t umem16 = (xrmem);                                                                                     \
         uint16_t uval16 = (word_value);                                                                                \
         __asm__ __volatile__(                                                                                          \
-            "move.w %[xra]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; move.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"            \
+            "move.w %[xra]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; move.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"              \
             :                                                                                                          \
             : [xra] "d"(umem16), [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                              \
             :);                                                                                                        \
@@ -173,7 +173,7 @@ typedef struct _xreg
     ({                                                                                                                 \
         (void)(XM_##xmreg);                                                                                            \
         uint16_t word_value;                                                                                           \
-        __asm__ __volatile__("move.w " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.w " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -184,7 +184,7 @@ typedef struct _xreg
     ({                                                                                                                 \
         (void)(XM_##xmreg);                                                                                            \
         uint32_t long_value;                                                                                           \
-        __asm__ __volatile__("move.l " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.l " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(long_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -199,7 +199,7 @@ typedef struct _xreg
     ({                                                                                                                 \
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, xrmem);                                                                                       \
-        __asm__ __volatile__("move.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -230,7 +230,7 @@ typedef struct _xreg
         (void)(XR_##xreg);                                                                                             \
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, (XR_##xreg));                                                                                 \
-        __asm__ __volatile__("move.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                            \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \

--- a/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_api.h
+++ b/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_api.h
@@ -82,9 +82,7 @@ typedef struct _xreg
         struct
         {
             volatile uint8_t h;
-            volatile uint8_t _h_pad;
             volatile uint8_t l;
-            volatile uint8_t _l_pad;
         } b;
         const volatile uint16_t w;        // NOTE: For use as offset only with xv_setw (and MOVEP.W opcode)
         const volatile uint32_t l;        // NOTE: For use as offset only with xv_setl (and MOVEP.L opcode)
@@ -109,7 +107,7 @@ typedef struct _xreg
     {                                                                                                                  \
         (void)(XM_##xmreg);                                                                                            \
         uint16_t uval16 = (word_value);                                                                                \
-        __asm__ __volatile__("movep.w %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
+        __asm__ __volatile__("move.w %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
                              :                                                                                         \
                              : [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                                \
                              :);                                                                                       \
@@ -121,7 +119,7 @@ typedef struct _xreg
     {                                                                                                                  \
         (void)(XM_##xmreg);                                                                                            \
         uint32_t uval32 = (long_value);                                                                                \
-        __asm__ __volatile__("movep.l %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
+        __asm__ __volatile__("move.l %[src]," XM_STR(XM_##xmreg) "(%[ptr])"                                           \
                              :                                                                                         \
                              : [src] "d"(uval32), [ptr] "a"(xosera_ptr)                                                \
                              :);                                                                                       \
@@ -134,7 +132,7 @@ typedef struct _xreg
         uint16_t uval16 = (word_value);                                                                                \
         if (__builtin_constant_p((XR_##xreg)) && __builtin_constant_p((word_value)))                                   \
         {                                                                                                              \
-            __asm__ __volatile__("movep.l %[rxav]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; "                                   \
+            __asm__ __volatile__("move.l %[rxav]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; "                                   \
                                  :                                                                                     \
                                  : [rxav] "d"(((XR_##xreg) << 16) | (uint16_t)((word_value))), [ptr] "a"(xosera_ptr)   \
                                  :);                                                                                   \
@@ -142,7 +140,7 @@ typedef struct _xreg
         else                                                                                                           \
         {                                                                                                              \
             __asm__ __volatile__(                                                                                      \
-                "movep.w %[rxa]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; movep.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"        \
+                "move.w %[rxa]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; move.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"        \
                 :                                                                                                      \
                 : [rxa] "d"((XR_##xreg)), [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                     \
                 :);                                                                                                    \
@@ -156,7 +154,7 @@ typedef struct _xreg
         uint16_t umem16 = (xrmem);                                                                                     \
         uint16_t uval16 = (word_value);                                                                                \
         __asm__ __volatile__(                                                                                          \
-            "movep.w %[xra]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; movep.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"            \
+            "move.w %[xra]," XM_STR(XM_XR_ADDR) "(%[ptr]) ; move.w %[src]," XM_STR(XM_XR_DATA) "(%[ptr])"            \
             :                                                                                                          \
             : [xra] "d"(umem16), [src] "d"(uval16), [ptr] "a"(xosera_ptr)                                              \
             :);                                                                                                        \
@@ -175,7 +173,7 @@ typedef struct _xreg
     ({                                                                                                                 \
         (void)(XM_##xmreg);                                                                                            \
         uint16_t word_value;                                                                                           \
-        __asm__ __volatile__("movep.w " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.w " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -186,7 +184,7 @@ typedef struct _xreg
     ({                                                                                                                 \
         (void)(XM_##xmreg);                                                                                            \
         uint32_t long_value;                                                                                           \
-        __asm__ __volatile__("movep.l " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.l " XM_STR(XM_##xmreg) "(%[ptr]),%[dst]"                                           \
                              : [dst] "=d"(long_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -201,7 +199,7 @@ typedef struct _xreg
     ({                                                                                                                 \
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, xrmem);                                                                                       \
-        __asm__ __volatile__("movep.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \
@@ -232,7 +230,7 @@ typedef struct _xreg
         (void)(XR_##xreg);                                                                                             \
         uint16_t word_value;                                                                                           \
         xm_setw(XR_ADDR, (XR_##xreg));                                                                                 \
-        __asm__ __volatile__("movep.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
+        __asm__ __volatile__("move.w " XM_STR(XM_XR_DATA) "(%[ptr]),%[dst]"                                           \
                              : [dst] "=d"(word_value)                                                                  \
                              : [ptr] "a"(xosera_ptr)                                                                   \
                              :);                                                                                       \

--- a/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.h
+++ b/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.h
@@ -34,10 +34,10 @@
 #define XM_XR_DATA   0x2         // (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)
 #define XM_RD_INCR   0x4         // (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2
 #define XM_RD_ADDR   0x6         // (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read
-#define XM_WR_INCR   0x8        // (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2
-#define XM_WR_ADDR   0xA        // (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written
-#define XM_DATA      0xC        // (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR)
-#define XM_DATA_2    0xE        // (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)
+#define XM_WR_INCR   0x8         // (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2
+#define XM_WR_ADDR   0xA         // (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written
+#define XM_DATA      0xC         // (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR)
+#define XM_DATA_2    0xE         // (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)
 #define XM_SYS_CTRL  0x10        // (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking
 #define XM_TIMER     0x12        // (RO   ) read 1/10th millisecond timer [TODO]
 #define XM_UNUSED_A  0x14        // (R /W ) unused direct register 0xA [TODO]

--- a/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.h
+++ b/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.h
@@ -26,27 +26,26 @@
 
 // See: https://github.com/XarkLabs/Xosera/blob/master/REFERENCE.md
 
-#define XM_BASEADDR 0xf80060        // Xosera rosco_m68k register base address
+#define XM_BASEADDR 0xff800020        // Xosera rosco_m68k register base address
 
 // Xosera Main Registers (XM Registers, directly CPU accessable)
-// NOTE: Main register numbers are multiplied by 4 for rosco_m68k, because of even byte 6800 8-bit addressing plus
 // 16-bit registers
 #define XM_XR_ADDR   0x0         // (R /W+) XR register number/address for XM_XR_DATA read/write access
-#define XM_XR_DATA   0x4         // (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)
-#define XM_RD_INCR   0x8         // (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2
-#define XM_RD_ADDR   0xC         // (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read
-#define XM_WR_INCR   0x10        // (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2
-#define XM_WR_ADDR   0x14        // (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written
-#define XM_DATA      0x18        // (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR)
-#define XM_DATA_2    0x1C        // (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)
-#define XM_SYS_CTRL  0x20        // (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking
-#define XM_TIMER     0x24        // (RO   ) read 1/10th millisecond timer [TODO]
-#define XM_UNUSED_A  0x28        // (R /W ) unused direct register 0xA [TODO]
-#define XM_UNUSED_B  0x2C        // (R /W ) unused direct register 0xB [TODO]
-#define XM_RW_INCR   0x30        // (R /W ) XM_RW_ADDR increment value on read/write of XM_RW_DATA/XM_RW_DATA_2
-#define XM_RW_ADDR   0x34        // (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2
-#define XM_RW_DATA   0x38        // (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)
-#define XM_RW_DATA_2 0x3C        // (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)
+#define XM_XR_DATA   0x2         // (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)
+#define XM_RD_INCR   0x4         // (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2
+#define XM_RD_ADDR   0x6         // (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read
+#define XM_WR_INCR   0x8        // (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2
+#define XM_WR_ADDR   0xA        // (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written
+#define XM_DATA      0xC        // (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR)
+#define XM_DATA_2    0xE        // (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)
+#define XM_SYS_CTRL  0x10        // (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking
+#define XM_TIMER     0x12        // (RO   ) read 1/10th millisecond timer [TODO]
+#define XM_UNUSED_A  0x14        // (R /W ) unused direct register 0xA [TODO]
+#define XM_UNUSED_B  0x16        // (R /W ) unused direct register 0xB [TODO]
+#define XM_RW_INCR   0x18        // (R /W ) XM_RW_ADDR increment value on read/write of XM_RW_DATA/XM_RW_DATA_2
+#define XM_RW_ADDR   0x1A        // (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2
+#define XM_RW_DATA   0x1C        // (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)
+#define XM_RW_DATA_2 0x1E        // (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)
 
 // XR Extended Register / Region (accessed via XM_XR_ADDR and XM_XR_DATA)
 

--- a/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.inc
+++ b/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.inc
@@ -25,27 +25,27 @@
 
 ; See: https://github.com/XarkLabs/Xosera/blob/master/REFERENCE.md
 
-XM_BASEADDR     equ     $f80060     ; Xosera rosco_m68k register base address
+XM_BASEADDR     equ     $ff800020     ; Xosera rosco_m68k register base address
 
 ; Xosera Main Registers (XM Registers, directly CPU accessable)
 ; NOTE: Main register numbers are multiplied by 4 for rosco_m68k, because of even byte 6800 8-bit addressing plus
 ; 16-bit registers
 XM_XR_ADDR      equ     $0          ; (R /W+) XR register number/address for XM_XR_DATA read/write access                         
-XM_XR_DATA      equ     $4          ; (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)           
-XM_RD_INCR      equ     $8          ; (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2                      
-XM_RD_ADDR      equ     $C          ; (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read                 
-XM_WR_INCR      equ     $10         ; (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2                    
-XM_WR_ADDR      equ     $14         ; (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written                
-XM_DATA         equ     $18         ; (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR) 
-XM_DATA_2       equ     $1C         ; (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)                                  
-XM_SYS_CTRL     equ     $20         ; (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking                   
-XM_TIMER        equ     $24         ; (RO   ) read 1/10th millisecond timer [TODO]                                       
-XM_UNUSED_A     equ     $28         ; (R /W ) unused direct register 0xA [TODO]                                                     
-XM_UNUSED_B     equ     $2C         ; (R /W ) unused direct register 0xB [TODO]                                                     
-XM_RW_INCR      equ     $30         ; (R /W ) XM_RW_ADDR increment value on read/write of XM_RW_DATA/XM_RW_DATA_2             
-XM_RW_ADDR      equ     $34         ; (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2                   
-XM_RW_DATA      equ     $38         ; (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)                           
-XM_RW_DATA_2    equ     $3C         ; (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)                               
+XM_XR_DATA      equ     $2          ; (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)           
+XM_RD_INCR      equ     $4          ; (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2                      
+XM_RD_ADDR      equ     $6          ; (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read                 
+XM_WR_INCR      equ     $8         ; (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2                    
+XM_WR_ADDR      equ     $A         ; (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written                
+XM_DATA         equ     $C         ; (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR) 
+XM_DATA_2       equ     $E         ; (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)                                  
+XM_SYS_CTRL     equ     $10         ; (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking                   
+XM_TIMER        equ     $12         ; (RO   ) read 1/10th millisecond timer [TODO]                                       
+XM_UNUSED_A     equ     $14         ; (R /W ) unused direct register 0xA [TODO]                                                     
+XM_UNUSED_B     equ     $16         ; (R /W ) unused direct register 0xB [TODO]                                                     
+XM_RW_INCR      equ     $18         ; (R /W ) XM_RW_ADDR increment value on read/write of XM_RW_DATA/XM_RW_DATA_2             
+XM_RW_ADDR      equ     $1A         ; (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2                   
+XM_RW_DATA      equ     $1C         ; (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)                           
+XM_RW_DATA_2    equ     $1E         ; (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)                               
 
 ; XR Extended Register / Region (accessed via XM_XR_ADDR and XM_XR_DATA)
 

--- a/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.inc
+++ b/code/firmware/rosco_m68k_pro_development/videoXoseraANSI/xosera_m68k_defs.inc
@@ -28,16 +28,15 @@
 XM_BASEADDR     equ     $ff800020     ; Xosera rosco_m68k register base address
 
 ; Xosera Main Registers (XM Registers, directly CPU accessable)
-; NOTE: Main register numbers are multiplied by 4 for rosco_m68k, because of even byte 6800 8-bit addressing plus
-; 16-bit registers
+; NOTE: Main register numbers are multiplied by 2 for rosco_m68k, because of 16-bit registers
 XM_XR_ADDR      equ     $0          ; (R /W+) XR register number/address for XM_XR_DATA read/write access                         
 XM_XR_DATA      equ     $2          ; (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)           
 XM_RD_INCR      equ     $4          ; (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2                      
 XM_RD_ADDR      equ     $6          ; (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read                 
-XM_WR_INCR      equ     $8         ; (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2                    
-XM_WR_ADDR      equ     $A         ; (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written                
-XM_DATA         equ     $C         ; (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR) 
-XM_DATA_2       equ     $E         ; (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)                                  
+XM_WR_INCR      equ     $8          ; (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2                    
+XM_WR_ADDR      equ     $A          ; (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written                
+XM_DATA         equ     $C          ; (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR) 
+XM_DATA_2       equ     $E          ; (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)                                  
 XM_SYS_CTRL     equ     $10         ; (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking                   
 XM_TIMER        equ     $12         ; (RO   ) read 1/10th millisecond timer [TODO]                                       
 XM_UNUSED_A     equ     $14         ; (R /W ) unused direct register 0xA [TODO]                                                     


### PR DESCRIPTION
Initial bootstrap of Xosera ANSI terminal with new memory layout on the Pro.

**Very** lightly tested at this point, but at least basically functional, we can build on these changes. 

Proof of life:

![image](https://user-images.githubusercontent.com/2096421/147748043-83074a40-35b7-4e06-85f7-cec424214e6f.png)

This also does a bit of tidy up in `machine.h` (based on some comments in the Xosera ANSI source) and fixes an issue with the firmware address in the link script (which caused an early LED-flash bus error with the ANSI terminal).
